### PR TITLE
Remove :q from owner specific queue keys as it's not needed

### DIFF
--- a/queues/fair.go
+++ b/queues/fair.go
@@ -15,10 +15,10 @@ import (
 //   - {foo}:active - set of owners scored by number of active tasks
 //   - {foo}:paused - set of paused owners
 //   - {foo}:temp - used internally
-//   - {foo:q:o1}/0 - e.g. list of tasks for o1 with priority 0 (low)
-//   - {foo:q:o1}/1 - e.g. list of tasks for o1 with priority 1 (high)
-//   - {foo:q:o2}/0 - e.g. list of tasks for o2 with priority 0 (low)
-//   - {foo:q:o2}/1 - e.g. list of tasks for o2 with priority 1 (high)
+//   - {foo:o1}/0 - e.g. list of tasks for o1 with priority 0 (low)
+//   - {foo:o1}/1 - e.g. list of tasks for o1 with priority 1 (high)
+//   - {foo:o2}/0 - e.g. list of tasks for o2 with priority 0 (low)
+//   - {foo:o2}/1 - e.g. list of tasks for o2 with priority 1 (high)
 type Fair struct {
 	keyBase           string
 	maxActivePerOwner int // max number of active tasks per owner
@@ -191,7 +191,7 @@ func (q *Fair) tempKey() string {
 
 func (q *Fair) queueKeys(owner string) [2]string {
 	return [2]string{
-		fmt.Sprintf("{%s:q:%s}/0", q.keyBase, owner),
-		fmt.Sprintf("{%s:q:%s}/1", q.keyBase, owner),
+		fmt.Sprintf("{%s:%s}/0", q.keyBase, owner),
+		fmt.Sprintf("{%s:%s}/1", q.keyBase, owner),
 	}
 }

--- a/queues/fair_test.go
+++ b/queues/fair_test.go
@@ -50,10 +50,10 @@ func TestFair(t *testing.T) {
 	// nobody processing any tasks so no workers assigned in active set
 	assertvk.ZGetAll(t, vc, "{test}:queued", map[string]float64{"owner1": 3, "owner2": 2})
 	assertvk.ZGetAll(t, vc, "{test}:active", map[string]float64{})
-	assertvk.LGetAll(t, vc, "{test:q:owner1}/0", []string{`task1`, `task4`})
-	assertvk.LGetAll(t, vc, "{test:q:owner1}/1", []string{`task2`})
-	assertvk.LGetAll(t, vc, "{test:q:owner2}/0", []string{`task3`})
-	assertvk.LGetAll(t, vc, "{test:q:owner2}/1", []string{`task5`})
+	assertvk.LGetAll(t, vc, "{test:owner1}/0", []string{`task1`, `task4`})
+	assertvk.LGetAll(t, vc, "{test:owner1}/1", []string{`task2`})
+	assertvk.LGetAll(t, vc, "{test:owner2}/0", []string{`task3`})
+	assertvk.LGetAll(t, vc, "{test:owner2}/1", []string{`task5`})
 
 	assertSize("owner1", 3)
 	assertSize("owner2", 2)
@@ -131,8 +131,8 @@ func TestFair(t *testing.T) {
 	q.Push(ctx, vc, "owner1", false, []byte("task6"))
 	q.Push(ctx, vc, "owner2", false, []byte("task7"))
 
-	assertvk.LLen(t, vc, "{test:q:owner1}/0", 1)
-	_, err = vc.Do("DEL", "{test:q:owner1}/0")
+	assertvk.LLen(t, vc, "{test:owner1}/0", 1)
+	_, err = vc.Do("DEL", "{test:owner1}/0")
 	assert.NoError(t, err)
 
 	assertPop(t, q, vc, "owner2", "task7")
@@ -280,12 +280,12 @@ func TestFairConcurrency(t *testing.T) {
 
 	assertvk.ZGetAll(t, vc, "{test}:queued", map[string]float64{})
 	assertvk.ZGetAll(t, vc, "{test}:active", map[string]float64{})
-	assertvk.LGetAll(t, vc, "{test:q:owner1}/0", []string{})
-	assertvk.LGetAll(t, vc, "{test:q:owner1}/1", []string{})
-	assertvk.LGetAll(t, vc, "{test:q:owner2}/0", []string{})
-	assertvk.LGetAll(t, vc, "{test:q:owner2}/1", []string{})
-	assertvk.LGetAll(t, vc, "{test:q:owner3}/0", []string{})
-	assertvk.LGetAll(t, vc, "{test:q:owner3}/1", []string{})
+	assertvk.LGetAll(t, vc, "{test:owner1}/0", []string{})
+	assertvk.LGetAll(t, vc, "{test:owner1}/1", []string{})
+	assertvk.LGetAll(t, vc, "{test:owner2}/0", []string{})
+	assertvk.LGetAll(t, vc, "{test:owner2}/1", []string{})
+	assertvk.LGetAll(t, vc, "{test:owner3}/0", []string{})
+	assertvk.LGetAll(t, vc, "{test:owner3}/1", []string{})
 }
 
 // assertPop is a helper function that asserts the result of a Pop operation


### PR DESCRIPTION
Now that we're using hashtags, an owner string `queued` `{foo:queued}` can't clash with `{foo}:queued`